### PR TITLE
features: initial string serialization, orp added back for convenience

### DIFF
--- a/src/What4/Serialize/Parser.hs
+++ b/src/What4/Serialize/Parser.hs
@@ -798,14 +798,13 @@ readExpr (S.WFSAtom (ABool b)) = do
 readExpr (S.WFSAtom (AStr prefix content)) = do
   sym <- R.reader procSym
   case prefix of
-    "u" -> do
+    (Some W4.UnicodeRepr) -> do
       s <- liftIO $ W4.stringLit sym $ W4.UnicodeLiteral content
       return $ Some $ s
-    "u8" -> do
+    (Some W4.Char8Repr) -> do
       s <- liftIO $ W4.stringLit sym $ W4.Char8Literal $ T.encodeUtf8 content
       return $ Some $ s
-    "u16" -> E.throwError $ "Char16 strings are not yet supported"
-    _ -> E.throwError $ "unsupported string literal prefix: " ++ (T.unpack prefix)
+    (Some W4.Char16Repr) -> E.throwError $ "Char16 strings are not yet supported"
 readExpr (S.WFSAtom (AReal _)) = E.throwError $ "TODO: support readExpr for real literals"
 readExpr (S.WFSAtom (ABV len val)) = do
   -- This is a bitvector literal.
@@ -900,7 +899,7 @@ readSymFn ::
   => SExpr
   -> Processor sym (SomeSymFn sym)
 readSymFn (S.WFSList [ S.WFSAtom (AId "definedfn")
-                     , S.WFSAtom (AStr "" rawSymFnName)
+                     , S.WFSAtom (AStr _ rawSymFnName)
                      , rawFnType
                      , S.WFSList argVarsRaw
                      , bodyRaw
@@ -935,7 +934,7 @@ readSymFn (S.WFSList [ S.WFSAtom (AId "definedfn")
 readSymFn badSExp@(S.WFSList ((S.WFSAtom (AId "definedfn")):_)) =
   E.throwError $ ("invalid `definedfn`: " ++ (T.unpack $ printSExpr mempty badSExp))
 readSymFn (S.WFSList [ S.WFSAtom (AId "uninterpfn")
-                     , S.WFSAtom (AStr "" rawSymFnName)
+                     , S.WFSAtom (AStr _ rawSymFnName)
                      , rawFnType
                      ]) = do
   sym <- R.reader procSym

--- a/src/What4/Serialize/Printer.hs
+++ b/src/What4/Serialize/Printer.hs
@@ -319,7 +319,7 @@ convertSymFn symFn@(W4.ExprSymFn _ symFnName symFnInfo _) = do
                                    , envFreeVarEnv = fvEnv OMap.<>| (OMap.fromList argsWithFreshNames)})
               $ convertExprWithLet body
      return $ S.L [ ident "definedfn"
-                  , string "" $ W4.solverSymbolAsText symFnName
+                  , string (Some W4.UnicodeRepr) $ W4.solverSymbolAsText symFnName
                   , S.L ((ident "->"):sArgTs ++ [sRetT])
                   , S.L $ map ident freshArgNames
                   , sExpr
@@ -328,7 +328,7 @@ convertSymFn symFn@(W4.ExprSymFn _ symFnName symFnInfo _) = do
      let sArgTs = convertBaseTypes argTs
          sRetT = convertBaseType retT
      in return $ S.L [ ident "uninterpfn"
-                     , string "" $ W4.solverSymbolAsText symFnName
+                     , string (Some W4.UnicodeRepr) $ W4.solverSymbolAsText symFnName
                      , S.L ((ident "->"):sArgTs ++ [sRetT])
                      ]
    W4.MatlabSolverFnInfo _msfn _argTs _body ->
@@ -416,11 +416,11 @@ convertExpr initialExpr = do
         go (W4.SemiRingLiteral (W4.SemiRingBVRepr _ sz) val _) = return $ bitvec (fromInteger (toInteger (widthVal sz))) val
         go (W4.StringExpr str _) =
           case (W4.stringLiteralInfo str) of
-            W4.UnicodeRepr -> return $ string "u" (W4S.fromUnicodeLit str)
-            W4.Char8Repr -> return $ string "u8" $ T.decodeUtf8 $ W4S.fromChar8Lit str
+            W4.UnicodeRepr -> return $ string (Some W4.UnicodeRepr) (W4S.fromUnicodeLit str)
+            W4.Char8Repr -> return $ string (Some W4.Char8Repr) $ T.decodeUtf8 $ W4S.fromChar8Lit str
             W4.Char16Repr -> error "Char16 strings are not yet supported"
               -- TODO - there is no `W4S.toLEByteString` currently... hmm...
-              -- return $ string "u16" $ T.decodeUtf16LE $ W4S.toLEByteString $ W4S.fromChar16Lit str
+              -- return $ string (Some W4.Char16Repr) $ T.decodeUtf16LE $ W4S.toLEByteString $ W4S.fromChar16Lit str
         go (W4.BoolExpr b _) = return $ bool b
         go (W4.AppExpr appExpr) = convertAppExpr' appExpr
         go (W4.NonceAppExpr nae) =


### PR DESCRIPTION
String literals are serialized as `#format"contents ..."`, where `format` is used to define which kind of What4 string is being encoded (e.g., `u` for `Unicode`, etc).

`orp` was initially removed because What4 no longer has an explicit `or` in its AST, however some clients (semmc) still want to generate logical `or`s and it's easy to support, so I added it back.