### PR TITLE
Add support for GHC 8.4.

### DIFF
--- a/src/What4/Serialize/Parser.hs
+++ b/src/What4/Serialize/Parser.hs
@@ -501,7 +501,7 @@ readApp opRaw@(S.WFSAtom (AId operator)) operands = do
   prefixError ("in reading expression:\n"
                ++(T.unpack $ printSExpr mempty $ S.WFSList (opRaw:operands))++"\n") $
   -- Parse an expression of the form @(fnname operands ...)@
-    case lookupOp operator of
+    case lookupOp @sym operator of
       Just (Op1 arg_types fn) -> do
         args <- readExprs operands
         exprAssignment arg_types args >>= \case


### PR DESCRIPTION
Older GHC 8.4 compilation is unable to unify the `sym` type parameter
between the `lookupOp` and its caller without the type application
added by this patch.  The corresponding errors look something like:

```
src/What4/Serialize/Parser.hs:504:10: error:
    • Could not deduce (W4.IsSymExprBuilder sym0)
        arising from a use of ‘lookupOp’
      from the context: (W4.IsSymExprBuilder sym, ShowF (W4.SymExpr sym))
        bound by the type signature for:
                   readApp :: forall sym.
                              (W4.IsSymExprBuilder sym, ShowF (W4.SymExpr sym)) =>
                              SExpr -> [SExpr] -> Processor sym (Some (W4.SymExpr sym))
        at src/What4/Serialize/Parser.hs:(481,1)-(485,42)
      The type variable ‘sym0’ is ambiguous
      These potential instance exist:
        instance W4.IsSymExprBuilder (W4.ExprBuilder t st fs)
          -- Defined in ‘What4.Expr.Builder’
    • In the expression: lookupOp operator
```