### PR TITLE
Update to the newest release of what4

### DIFF
--- a/src/What4/Serialize/Normalize.hs
+++ b/src/What4/Serialize/Normalize.hs
@@ -37,7 +37,7 @@ import           Data.Parameterized.Classes
 
 normSymFn :: forall sym st fs t args ret. sym ~ B.ExprBuilder t st fs
           => sym
-          -> B.ExprSymFn t (B.Expr t) args ret
+          -> B.ExprSymFn t args ret
           -> Ctx.Assignment (S.Expr t) args
           -> IO (S.Expr t ret)
 normSymFn sym symFn argEs = case B.symFnInfo symFn of

--- a/src/What4/Serialize/Parser.hs
+++ b/src/What4/Serialize/Parser.hs
@@ -211,7 +211,6 @@ readBaseType sexpr =
     S.WFSAtom (AId atom) ->
       case (T.unpack atom) of
         "Bool" -> return $ Some BaseBoolRepr
-        "Nat" -> return $ Some BaseNatRepr
         "Int" -> return $ Some BaseIntegerRepr
         "Real" -> return $ Some BaseRealRepr
         "String" -> return $ Some (BaseStringRepr UnicodeRepr)
@@ -332,10 +331,6 @@ opTable =
   , ("orp", Op2 knownRepr $ W4.orPred)
   , ("xorp", Op2 knownRepr $ W4.xorPred)
   , ("notp", Op1 knownRepr $ W4.notPred)
-  -- -- -- Natural ops -- -- --
-  , ("natmul", Op2 knownRepr $ W4.natMul)
-  , ("natadd", Op2 knownRepr $ W4.natAdd)
-  , ("natle", Op2 knownRepr $ W4.natLe)
   -- -- -- Integer ops -- -- --
   , ("intmul", Op2 knownRepr $ W4.intMul)
   , ("intadd", Op2 knownRepr $ W4.intAdd)
@@ -798,12 +793,14 @@ readExpr ::
 readExpr (S.WFSAtom (AInt n)) = do
   sym <- R.reader procSym
   liftIO $ (Some <$> W4.intLit sym n)
-readExpr (S.WFSAtom (ANat n)) = do
-  sym <- R.reader procSym
-  liftIO $ (Some <$> W4.natLit sym n)
+readExpr (S.WFSAtom (ANat _)) =
+  E.throwError "Bare Natural literals are no longer used"
 readExpr (S.WFSAtom (ABool b)) = do
   sym <- R.reader procSym
   liftIO $ return $ Some $ W4.backendPred sym b
+readExpr (S.WFSAtom (AFloat (Some repr) bf)) = do
+  sym <- R.reader procSym
+  liftIO $ (Some <$> W4.floatLit sym repr bf)
 readExpr (S.WFSAtom (AStr prefix content)) = do
   sym <- R.reader procSym
   case prefix of

--- a/src/What4/Serialize/SETokens.hs
+++ b/src/What4/Serialize/SETokens.hs
@@ -231,14 +231,15 @@ parseFloat = do
      <- read <$> P.many1 P.digit
   _ <- P.char '#'
 
+  -- The float value itself is printed out as a hex literal
+  hexDigits <- P.many1 P.hexDigit
+
   Some ebRepr <- return (PN.mkNatRepr eb)
   Some sbRepr <- return (PN.mkNatRepr sb)
   case (PN.testLeq (PN.knownNat @2) ebRepr, PN.testLeq (PN.knownNat @2) sbRepr) of
     (Just PN.LeqProof, Just PN.LeqProof) -> do
       let rep = W4.FloatingPointPrecisionRepr ebRepr sbRepr
 
-      -- The float value itself is printed out as a hex literal
-      hexDigits <- P.many1 P.hexDigit
       -- We know our format: it is determined by the exponent bits (eb) and the
       -- significand bits (sb) parsed above
       let fmt = BF.precBits (fromIntegral sb) <> BF.expBits (fromIntegral eb)

--- a/src/What4/Utils/Log.hs
+++ b/src/What4/Utils/Log.hs
@@ -59,7 +59,6 @@ module What4.Utils.Log (
   namedM
   ) where
 
-import qualified GHC.Err.Located as Ghc
 import qualified GHC.Stack as Ghc
 
 import qualified Control.Concurrent as Cc
@@ -448,4 +447,4 @@ writeLogEvent cfg cs level msg = do
                  (_,topSrcLoc):rest -> case rest of
                    []                 -> (Nothing,           topSrcLoc)
                    (enclosingFun,_):_ -> (Just enclosingFun, topSrcLoc)
-                 [] -> Ghc.error "Do we ever not have a call site?"
+                 [] -> error "Do we ever not have a call site?"

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -34,7 +34,7 @@ debugOut msg = liftIO $ do appendFile debugFile (msg <> "\n")
 alwaysPrint = liftIO . putStrLn
 
 
-showSymFn :: S.ExprSymFn t (S.Expr t) args ret -> String
+showSymFn :: S.ExprSymFn t args ret -> String
 showSymFn fn = case S.symFnInfo fn of
   S.DefinedFnInfo _ expr _ -> (show $ WI.printSymExpr expr)
   _ -> ""

--- a/what4-serialize.cabal
+++ b/what4-serialize.cabal
@@ -32,7 +32,7 @@ library
     transformers,
     time,
     unliftio >= 0.2 && < 0.3,
-    libBF >= 0.6 && < 0.7,
+    libBF >= 0.6.2 && < 0.7,
     what4 >= 1.1 && < 1.2,
     ghc-prim
 

--- a/what4-serialize.cabal
+++ b/what4-serialize.cabal
@@ -67,6 +67,7 @@ test-suite what4-serialize-tests
                  , directory
                  , exceptions
                  , hedgehog
+                 , libBF
                  , tasty
                  , tasty-hunit
                  , tasty-hedgehog

--- a/what4-serialize.cabal
+++ b/what4-serialize.cabal
@@ -16,13 +16,12 @@ library
   build-depends:
     base >= 4.8 && < 5,
     bv-sized >= 1.0.0 && < 1.1,
-    BoundedChan,
+    BoundedChan >= 1 && < 2,
     containers >= 0.5.0.0,
-    directory,
-    located-base,
-    mtl,
-    ordered-containers,
-    megaparsec >= 7 && < 9,
+    directory >= 1.2 && < 1.4,
+    mtl >= 2.2 && < 2.3,
+    ordered-containers >= 0.2 && < 0.3,
+    megaparsec >= 7 && < 10,
     unordered-containers >= 0.2 && < 0.3,
     parsec >= 3.1 && < 3.2,
     parameterized-utils >= 2.1.0 && < 2.2,
@@ -32,8 +31,9 @@ library
     text,
     transformers,
     time,
-    unliftio,
-    what4,
+    unliftio >= 0.2 && < 0.3,
+    libBF >= 0.6 && < 0.7,
+    what4 >= 1.1 && < 1.2,
     ghc-prim
 
   default-language: Haskell2010


### PR DESCRIPTION
The nat type has been demoted to no longer be a base type.

The remaining issue is that the tests are failing due to some unhandled array
operations that are now generated more often.

Fixes #16 