### PR TITLE
Allow building with GHC 9.2 without warnings

### DIFF
--- a/src/What4/Serialize/Parser.hs
+++ b/src/What4/Serialize/Parser.hs
@@ -528,25 +528,21 @@ readApp opRaw@(S.WFSAtom (AId operator)) operands = do
         exprAssignment arg_types args >>= \case
           Ctx.Empty Ctx.:> arg1 ->
             liftIO (Some <$> fn sym arg1)
-          _ -> E.throwError "Unable to unpack Op1 arg in Formula.Parser readApp"
       Just (Op2 arg_types fn) -> do
         args <- readExprs operands
         exprAssignment arg_types args >>= \case
           Ctx.Empty Ctx.:> arg1 Ctx.:> arg2 ->
               liftIO (Some <$> fn sym arg1 arg2)
-          _ -> E.throwError "Unable to unpack Op2 arg in Formula.Parser readApp"
       Just (Op3 arg_types fn) -> do
         args <- readExprs operands
         exprAssignment arg_types args >>= \case
           Ctx.Empty Ctx.:> arg1 Ctx.:> arg2 Ctx.:> arg3 ->
               liftIO (Some <$> fn sym arg1 arg2 arg3)
-          _ -> E.throwError "Unable to unpack Op3 arg in Formula.Parser readApp"
       Just (Op4 arg_types fn) -> do
         args <- readExprs operands
         exprAssignment arg_types args >>= \case
           Ctx.Empty Ctx.:> arg1 Ctx.:> arg2 Ctx.:> arg3 Ctx.:> arg4 ->
               liftIO (Some <$> fn sym arg1 arg2 arg3 arg4)
-          _ -> E.throwError "Unable to unpack Op4 arg in Formula.Parser readApp"
       Just (BVOp1 op) -> do
         Some expr <- readOneArg operands
         BVProof _ <- getBVProof expr

--- a/src/What4/Serialize/Printer.hs
+++ b/src/What4/Serialize/Printer.hs
@@ -437,6 +437,7 @@ convertExpr initialExpr = do
             W4.ArrayFromFn {} -> error "ArrayFromFn NonceAppExpr not yet supported"
             W4.MapOverArrays {} -> error "MapOverArrays NonceAppExpr not yet supported"
             W4.ArrayTrueOnEntries {} -> error "ArrayTrueOnEntries NonceAppExpr not yet supported"
+            W4.Annotation {} -> error "Annotation NonceAppExpr not yet supported"
         go (W4.BoundVarExpr var) = convertBoundVarExpr var
 
 -- | Serialize bound variables as the s-expression identifier `name_nonce`. This allows us to

--- a/tests/SymFnTests.hs
+++ b/tests/SymFnTests.hs
@@ -21,6 +21,7 @@ import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Nonce
 import           Data.Parameterized.Some
 import           Data.Parameterized.TraversableFC
+import qualified Data.String as String
 import qualified Data.Text as T
 import qualified Data.Map as Map
 import qualified Data.Map.Ordered as OMap
@@ -29,7 +30,7 @@ import qualified LibBF as BF
 
 -- import qualified What4.Utils.Log as Log
 import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import           Test.Tasty.Hedgehog hiding (testProperty)
 import           TestUtils
 import qualified What4.Expr.Builder as S
 import           What4.BaseTypes
@@ -225,3 +226,19 @@ mkEquivalenceTest parseSExpr argTs getExpr = do
           fn1out <- liftIO $ WI.definedFn sym (WI.safeSymbol "fn") bvs expr WI.NeverUnfold
           symFnEqualityTest sym fn1out fn2
 
+-- | Create a 'T.TestTree' from a Hedgehog 'Property'.
+--
+-- Note that @tasty-hedgehog@'s version of 'testProperty' has been deprecated
+-- in favor of 'testPropertyNamed', whose second argument is intended to
+-- represent the name of a top-level 'Property' value to run in the event that
+-- the test fails. See https://github.com/qfpl/tasty-hedgehog/pull/42.
+--
+-- That being said, @what4-serialize@ currently does not define any of the
+-- properties that it tests as top-level values. In the
+-- meantime, we avoid incurring deprecation warnings by defining our own
+-- version of 'testProperty'. The downside to this workaround is that if a
+-- property fails, the error message it will produce will likely suggest
+-- running ill-formed Haskell code, so users will have to use context clues to
+-- determine how to /actually/ reproduce the error.
+testProperty :: TestName -> Property -> TestTree
+testProperty name = testPropertyNamed name (String.fromString name)

--- a/what4-serialize.cabal
+++ b/what4-serialize.cabal
@@ -70,7 +70,7 @@ test-suite what4-serialize-tests
                  , libBF
                  , tasty
                  , tasty-hunit
-                 , tasty-hedgehog
+                 , tasty-hedgehog >= 1.2
                  , text
                  , parameterized-utils
                  , async

--- a/what4-serialize.cabal
+++ b/what4-serialize.cabal
@@ -33,7 +33,7 @@ library
     time,
     unliftio >= 0.2 && < 0.3,
     libBF >= 0.6.2 && < 0.7,
-    what4 >= 1.1 && < 1.3,
+    what4 >= 1.1 && < 1.4,
     ghc-prim
 
   default-language: Haskell2010


### PR DESCRIPTION
For the most part, `what4-serialize` builds without issue on GHC 9.2 with a simple version bump. The rest of this PR is dedicated to fixing warnings, some of which were added to `-Wall` in 9.2, others which have likely been around for a while.